### PR TITLE
ci: remove coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
           pylint src
       - name: Test with pytest
         run: |
-          pytest --cov src tests/ --cov-fail-under=75
+          pytest --cov src tests/


### PR DESCRIPTION
potreste togliere la code coverage dalla pipeline, è un po' scomoda durante lo sviluppo